### PR TITLE
Add sample freight data and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The system automates insurance payouts for delayed freight shipments or risky we
 | Agentic AI     | Python (FastAPI + scheduler)   |
 | Frontend       | React + Vite                   |
 | Blockchain     | Stellar Testnet + Soroban      |
-| Data Sources   | Met Eireann, mock shipping ETA |
+| Data Sources   | Met Eireann, `data/mock_freight_data.json` |
 
 ---
 
@@ -56,9 +56,19 @@ parametric-insurance/
 ├── frontend/ # React UI with live alerts  
 │   └── components/
 │   └── pages/
-├── data/ # Sample freight data  
+├── data/
+│   └── mock_freight_data.json # sample shipping records
 ├── .env                  # API keys
 └── README.md # Project overview
+
+The agents load this dataset using the Python `json` module:
+
+```python
+import json
+
+with open("data/mock_freight_data.json") as f:
+    FREIGHT_DATA = json.load(f)  # list of ship records
+```
 
 ---
 
@@ -66,7 +76,7 @@ parametric-insurance/
 
 1. **User** enters policy in React UI → POSTs to Python backend → Python calls `init_policy` on Soroban.
 
-2. **Python Agent** fetches weather & mock freight data every 10 minutes.
+2. **Python Agent** fetches weather data and loads freight records from `data/mock_freight_data.json` every 10 minutes.
 
 3. **Evaluator Agent** checks for:
    

--- a/agentic/README.md
+++ b/agentic/README.md
@@ -8,7 +8,7 @@ This Python app runs an agentic AI workflow that monitors real-time shipping dat
 
 | Agent           | Task Description                                                                    |
 | --------------- | ----------------------------------------------------------------------------------- |
-| Data Agent      | Pull ETA and weather(Met Éireann) every 10 mins                                     |
+| Data Agent      | Load `../data/mock_freight_data.json` and pull weather (Met Éireann) every 10 mins |
 | Evaluator Agent | Evaluate if delay(actual vs declared) or weather breaches thresholds                |
 | Trigger Agent   | Call `check_and_payout()` on-chain when breached (delay > X hours or storm warning) |
 | Logger Agent    | Persist decision logs to file with alerts                                           |
@@ -20,7 +20,15 @@ This Python app runs an agentic AI workflow that monitors real-time shipping dat
 
 - **Weather**: Met Éireann (`wind_speed`, `storm`, `rain`)
 
-- **ETA**: mock data (Hardcode 3 ships: `ship_id = X` Each has: expected ETA + actual arrival (manually simulate delay))
+- **ETA**: sample shipping records stored in [`../data/mock_freight_data.json`](../data/mock_freight_data.json)
+
+```python
+# data_agent.py snippet
+import json
+
+with open("../data/mock_freight_data.json") as f:
+    FREIGHT_DATA = json.load(f)  # list of ship records
+```
 
 ---
 

--- a/data/mock_freight_data.json
+++ b/data/mock_freight_data.json
@@ -1,0 +1,82 @@
+[
+  {
+    "ship_id": "A001",
+    "expected_eta": "2024-07-20T10:00:00Z",
+    "actual_eta": "2024-07-20T12:30:00Z",
+    "origin": "Dublin",
+    "destination": "Hamburg",
+    "weather": {"wind_speed": 30, "conditions": "Clear"}
+  },
+  {
+    "ship_id": "A002",
+    "expected_eta": "2024-07-21T15:00:00Z",
+    "actual_eta": "2024-07-21T14:50:00Z",
+    "origin": "Liverpool",
+    "destination": "Rotterdam",
+    "weather": {"wind_speed": 20, "conditions": "Rain"}
+  },
+  {
+    "ship_id": "A003",
+    "expected_eta": "2024-07-22T09:00:00Z",
+    "actual_eta": "2024-07-22T09:05:00Z",
+    "origin": "Cork",
+    "destination": "Oslo",
+    "weather": {"wind_speed": 15, "conditions": "Fog"}
+  },
+  {
+    "ship_id": "A004",
+    "expected_eta": "2024-07-23T18:30:00Z",
+    "actual_eta": "2024-07-23T22:10:00Z",
+    "origin": "Brest",
+    "destination": "Gothenburg",
+    "weather": {"wind_speed": 50, "conditions": "Storm"}
+  },
+  {
+    "ship_id": "A005",
+    "expected_eta": "2024-07-24T11:45:00Z",
+    "actual_eta": "2024-07-24T11:40:00Z",
+    "origin": "Le Havre",
+    "destination": "Stockholm",
+    "weather": {"wind_speed": 12, "conditions": "Clear"}
+  },
+  {
+    "ship_id": "A006",
+    "expected_eta": "2024-07-25T07:30:00Z",
+    "actual_eta": "2024-07-25T08:15:00Z",
+    "origin": "Bilbao",
+    "destination": "Tallinn",
+    "weather": {"wind_speed": 40, "conditions": "Windy"}
+  },
+  {
+    "ship_id": "A007",
+    "expected_eta": "2024-07-26T13:20:00Z",
+    "actual_eta": "2024-07-26T13:25:00Z",
+    "origin": "Amsterdam",
+    "destination": "Copenhagen",
+    "weather": {"wind_speed": 18, "conditions": "Cloudy"}
+  },
+  {
+    "ship_id": "A008",
+    "expected_eta": "2024-07-27T16:40:00Z",
+    "actual_eta": "2024-07-27T20:00:00Z",
+    "origin": "Antwerp",
+    "destination": "Riga",
+    "weather": {"wind_speed": 55, "conditions": "Storm"}
+  },
+  {
+    "ship_id": "A009",
+    "expected_eta": "2024-07-28T21:00:00Z",
+    "actual_eta": "2024-07-28T21:10:00Z",
+    "origin": "London",
+    "destination": "St Petersburg",
+    "weather": {"wind_speed": 25, "conditions": "Rain"}
+  },
+  {
+    "ship_id": "A010",
+    "expected_eta": "2024-07-29T05:00:00Z",
+    "actual_eta": "2024-07-29T04:50:00Z",
+    "origin": "Lisbon",
+    "destination": "Gdansk",
+    "weather": {"wind_speed": 10, "conditions": "Clear"}
+  }
+]


### PR DESCRIPTION
## Summary
- provide `data/mock_freight_data.json` with ten example ship records
- document mock data loading in `README.md` and `agentic/README.md`
- show how the Data Agent reads the JSON file

## Testing
- `grep -c 'ship_id' data/mock_freight_data.json`


------
https://chatgpt.com/codex/tasks/task_e_68775aafacfc8329b63ab340baa488ca