### PR TITLE
Add root .gitignore for common build outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Python artifacts
+__pycache__/
+.env
+
+# Rust build directory
+target/
+
+# Node dependencies
+node_modules/


### PR DESCRIPTION
## Summary
- prevent common build artifacts from being committed by adding a root `.gitignore`
  - ignore Python `__pycache__/` and `.env`
  - ignore Rust `target/`
  - ignore Node `node_modules/`