### PR TITLE
Improve data source docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The system automates insurance payouts for delayed freight shipments or risky we
 | Agentic AI     | Python (FastAPI + scheduler)   |
 | Frontend       | React + Vite                   |
 | Blockchain     | Stellar Testnet + Soroban      |
-| Data Sources   | Met Eireann, `data/mock_freight_data.json` |
+| Data Sources   | Freight data from `data/mock_freight_data.json`, weather live via Met Éireann API |
 
 ---
 
@@ -39,6 +39,11 @@ The system automates insurance payouts for delayed freight shipments or risky we
    - [`agentic/README.md`](agentic/README.md)
    - [`frontend/README.md`](frontend/README.md)
 3. Run all services and demo your live workflow
+
+After starting the backend, the **DataAgent** loads freight records locally from
+`data/mock_freight_data.json` while fetching current weather from the Met
+Éireann API. This mix of local and live data keeps the demo self-contained yet
+realistic.
 
 ---
 


### PR DESCRIPTION
## Summary
- document that freight data is loaded from `data/mock_freight_data.json`
- explain that weather is fetched live from the Met Éireann API
- note in **Quickstart** how the DataAgent loads freight locally but pulls live weather

## Testing
- `cargo test` *(fails: failed to download crates due to 403 CONNECT tunnel)*

------
https://chatgpt.com/codex/tasks/task_e_6877705b00ec832996540c9ba931310c