### PR TITLE
Add Vite-based React frontend

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -40,6 +40,8 @@ cd frontend/
 npm install
 npm run dev
 ```
+The frontend is built with Vite and React. After installing dependencies,
+the development server will be available at `http://localhost:5173` by default.
 
 ## Suggested UI Structure
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Freight Insurance Dashboard</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "freight-insurance-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.3",
+    "vite": "^4.4.9"
+  }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import PolicyForm from './components/PolicyForm';
+import PolicyStatus from './components/PolicyStatus';
+import WeatherBox from './components/WeatherBox';
+import AlertBanner from './components/AlertBanner';
+import TxLog from './components/TxLog';
+
+// Simple layout referencing all components
+export default function App() {
+  return (
+    <div className="App">
+      <h1>Freight Insurance Dashboard</h1>
+      <AlertBanner />
+      <PolicyForm />
+      <PolicyStatus />
+      <WeatherBox />
+      <TxLog />
+    </div>
+  );
+}

--- a/frontend/src/components/AlertBanner.jsx
+++ b/frontend/src/components/AlertBanner.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+// Notifies user of payouts or potential risks
+export default function AlertBanner() {
+  return (
+    <div className="alert-banner">
+      <p>AlertBanner component stub</p>
+    </div>
+  );
+}

--- a/frontend/src/components/PolicyForm.jsx
+++ b/frontend/src/components/PolicyForm.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+// Form for creating new insurance policies
+export default function PolicyForm() {
+  return (
+    <div className="policy-form">
+      <p>PolicyForm component stub</p>
+    </div>
+  );
+}

--- a/frontend/src/components/PolicyStatus.jsx
+++ b/frontend/src/components/PolicyStatus.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+// Displays current policy status and ETA information
+export default function PolicyStatus() {
+  return (
+    <div className="policy-status">
+      <p>PolicyStatus component stub</p>
+    </div>
+  );
+}

--- a/frontend/src/components/TxLog.jsx
+++ b/frontend/src/components/TxLog.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+// Shows transaction history from the smart contract
+export default function TxLog() {
+  return (
+    <div className="tx-log">
+      <p>TxLog component stub</p>
+    </div>
+  );
+}

--- a/frontend/src/components/WeatherBox.jsx
+++ b/frontend/src/components/WeatherBox.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+// Shows current wind and weather conditions
+export default function WeatherBox() {
+  return (
+    <div className="weather-box">
+      <p>WeatherBox component stub</p>
+    </div>
+  );
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+// Mount the root React component
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+// basic Vite config with React plugin
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- scaffold a new Vite + React project under `frontend`
- implement component stubs per project README
- document how to run the dev server