### PR TITLE
Keep scheduler across events and shutdown cleanly

### DIFF
--- a/agentic/main.py
+++ b/agentic/main.py
@@ -12,6 +12,9 @@ DATA_PATH = "../data/mock_freight_data.json"
 
 app = FastAPI(title="Freight Insurance Agentic API")
 
+# Module-level scheduler so it can be reused across events
+scheduler = BackgroundScheduler()
+
 # Initialize agents
 _data_agent = DataAgent(DATA_PATH)
 _evaluator = EvaluatorAgent()
@@ -38,9 +41,15 @@ def monitor() -> None:
 @app.on_event("startup")
 def start_scheduler() -> None:
     """Launch background scheduler when the app starts."""
-    scheduler = BackgroundScheduler()
+    # Use the module-level scheduler defined above
     scheduler.add_job(monitor, "interval", minutes=10)
     scheduler.start()
+
+
+@app.on_event("shutdown")
+def shutdown_scheduler() -> None:
+    """Shut down the scheduler gracefully on shutdown."""
+    scheduler.shutdown()
 
 
 @app.post("/policy")


### PR DESCRIPTION
## Summary
- store the `BackgroundScheduler` at module scope so it's accessible across events
- add a shutdown handler that stops the scheduler

## Testing
- `python -m py_compile agentic/main.py`

------
https://chatgpt.com/codex/tasks/task_e_687783da60e08329b79b7018e618d0a8