### PR TITLE
Implement arrival registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ with open("data/mock_freight_data.json") as f:
 
 1. **User** enters policy in React UI → POSTs to Python backend → Python calls `init_policy` on Soroban.
 
-2. **Python Agent** fetches weather data and loads freight records from `data/mock_freight_data.json` every 10 minutes.
+2. **Python Agent** fetches weather data and loads freight records from `data/mock_freight_data.json` every 10 minutes, registering each arrival via `register_actual_arrival`.
 
 3. **Evaluator Agent** checks for:
    

--- a/agentic/agents/trigger_agent.py
+++ b/agentic/agents/trigger_agent.py
@@ -6,6 +6,13 @@ class TriggerAgent:
     def __init__(self):
         self.payout_log = []
 
+    def register_actual_arrival(self, record: Dict) -> None:
+        """Simulate calling the `register_actual_arrival` contract method."""
+        ship_id = record["ship_id"]
+        actual = record["actual_eta"]
+        # In a real system, this would send a transaction to the Soroban contract
+        print(f"Recorded arrival for {ship_id} at {actual}")
+
     def trigger_payout(self, record: Dict) -> None:
         """Simulate calling the `check_and_payout` contract method."""
         ship_id = record["ship_id"]

--- a/agentic/main.py
+++ b/agentic/main.py
@@ -33,6 +33,8 @@ def monitor() -> None:
         # Only evaluate if a policy exists for the ship
         if ship_id not in policies:
             continue
+        # Persist actual arrival on-chain
+        _trigger.register_actual_arrival(rec)
         should_trigger = _evaluator.evaluate(rec)
         _logger.log(rec, should_trigger)
         if should_trigger and ship_id not in _trigger.payout_log:

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -9,7 +9,7 @@ This Soroban smart contract manages insurance policy creation, monitoring, and p
 | Function              | Purpose                                                              |
 | --------------------- | -------------------------------------------------------------------- |
 | `init_policy()`       | Create and store a new insurance policy                              |
-| `register_arrival()`  | Log the actual arrival and compute delay + conditions                |
+| `register_actual_arrival()` | Store the actual arrival time and trigger payout check |
 | `check_and_payout()`  | Trigger payout if delay threshold met, auto-payout in testnet tokens |
 | `get_policy_status()` | Query policy state: Active, Triggered                                |
 
@@ -34,7 +34,7 @@ Map<ship_id => payout_amount>
 
 2. <u>**Register Arrival**</u>
 
-`register_actual_arrival(   ship_id: BytesN<32>,   actual_eta: u64,   wind_speed: Option<u32> )`
+`register_actual_arrival(ship_id: BytesN<32>, actual_eta: u64)`
 
 3. <u>**Check & Payout**</u>
 

--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -33,6 +33,15 @@ impl FreightInsurance {
         p.set(&DataKey::PayoutDone(ship_id), &false);
     }
 
+    /// Store the actual arrival timestamp for a ship.
+    /// Also trigger payout check immediately after saving.
+    pub fn register_actual_arrival(env: Env, ship_id: BytesN<32>, actual_eta: u64) {
+        let p = env.storage().persistent();
+        p.set(&DataKey::ActualEta(ship_id.clone()), &actual_eta);
+        // Automatically evaluate payout conditions when arrival is recorded
+        let _ = Self::check_and_payout(env, ship_id);
+    }
+
     pub fn check_and_payout(env: Env, ship_id: BytesN<32>) -> bool {
         let p = env.storage().persistent();
         let expected: u64 = p.get(&DataKey::ExpectedEta(ship_id.clone())).unwrap();


### PR DESCRIPTION
## Summary
- log actual ship arrival on-chain via new `register_actual_arrival` method
- update docs for the new contract method
- register arrivals in the Python agent before evaluating payout