### PR TITLE
Add collapsible sidebar layout

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,17 +4,21 @@ import PolicyStatus from './components/PolicyStatus';
 import WeatherBox from './components/WeatherBox';
 import AlertBanner from './components/AlertBanner';
 import TxLog from './components/TxLog';
+import DashboardLayout from './components/DashboardLayout';
 
 // Simple layout referencing all components
 export default function App() {
   return (
-    <div className="App">
-      <h1>Freight Insurance Dashboard</h1>
-      <AlertBanner />
-      <PolicyForm />
-      <PolicyStatus />
-      <WeatherBox />
-      <TxLog />
-    </div>
+    // wrap existing components in new dashboard layout
+    <DashboardLayout>
+      <div className="App"> {/* page header + widgets */}
+        <h1>Freight Insurance Dashboard</h1>
+        <AlertBanner />
+        <PolicyForm />
+        <PolicyStatus />
+        <WeatherBox />
+        <TxLog />
+      </div>
+    </DashboardLayout>
   );
 }

--- a/frontend/src/components/DashboardLayout.jsx
+++ b/frontend/src/components/DashboardLayout.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import Sidebar from './Sidebar';
+
+// Layout component placing sidebar next to main content
+export default function DashboardLayout({ children }) {
+  return (
+    <div className="dashboard-layout"> {/* layout wrapper */}
+      <Sidebar />
+      <main className="content">{/* main content container */}
+        {children}
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -1,0 +1,24 @@
+import React, { useState } from 'react';
+
+// Collapsible sidebar with navigation links
+export default function Sidebar() {
+  // collapsed state toggles visibility of link list
+  const [collapsed, setCollapsed] = useState(false);
+
+  return (
+    <div className={`sidebar ${collapsed ? 'collapsed' : ''}`}> {/* sidebar wrapper */}
+      <button onClick={() => setCollapsed(!collapsed)}>
+        {collapsed ? 'Expand' : 'Collapse'}
+      </button>
+      {/* only show links when expanded */}
+      {!collapsed && (
+        <ul>
+          <li><a href="#policies">Policies</a></li>
+          <li><a href="#transactions">Transactions</a></li>
+          <li><a href="#analytics">Analytics</a></li>
+          <li><a href="#settings">Settings</a></li>
+        </ul>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create a collapsible `Sidebar` with navigation links
- add `DashboardLayout` to place sidebar next to content
- wrap existing dashboard widgets with the new layout