### PR TITLE
Add policy analytics dashboard

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,13 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "axios": "^1.6.7"
+    "axios": "^1.6.7",
+    "chart.js": "^4.4.1",
+    "react-chartjs-2": "^5.2.0",
+    "leaflet": "^1.9.4",
+    "react-leaflet": "^4.2.2",
+    "jspdf": "^2.5.1",
+    "file-saver": "^2.0.5"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.0.3",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,6 +4,7 @@ import PolicyStatus from './components/PolicyStatus';
 import WeatherBox from './components/WeatherBox';
 import AlertBanner from './components/AlertBanner';
 import TxLog from './components/TxLog';
+import Dashboard from './components/Dashboard';
 
 // Simple layout referencing all components
 export default function App() {
@@ -15,6 +16,8 @@ export default function App() {
       <PolicyStatus />
       <WeatherBox />
       <TxLog />
+      {/* analytics dashboard with charts and map */}
+      <Dashboard />
     </div>
   );
 }

--- a/frontend/src/components/ChartView.jsx
+++ b/frontend/src/components/ChartView.jsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { Bar, Line } from 'react-chartjs-2';
+import {
+  Chart,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  BarElement,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+
+// register chart.js components once
+Chart.register(
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  BarElement,
+  Tooltip,
+  Legend
+);
+
+// display policy counts and claim trends
+export default function ChartView({ data }) {
+  const activeCount = data.filter((d) => !d.payout).length;
+  const payoutCount = data.filter((d) => d.payout).length;
+
+  // bar chart of policy counts
+  const barData = {
+    labels: ['Active', 'Payout'],
+    datasets: [
+      {
+        label: 'Policies',
+        data: [activeCount, payoutCount],
+        backgroundColor: ['#36a2eb', '#ff6384'],
+      },
+    ],
+  };
+
+  // line chart of delay hours per ship
+  const lineData = {
+    labels: data.map((d) => d.ship_id),
+    datasets: [
+      {
+        label: 'Delay Hours',
+        data: data.map((d) => {
+          const expected = new Date(d.policy.expected_eta);
+          const actual = new Date(d.policy.actual_eta);
+          return Math.max((actual - expected) / 3600000, 0);
+        }),
+        borderColor: '#4bc0c0',
+        fill: false,
+      },
+    ],
+  };
+
+  return (
+    <div className="chart-view">
+      {/* show bar and line charts */}
+      <Bar data={barData} />
+      <Line data={lineData} />
+    </div>
+  );
+}

--- a/frontend/src/components/Dashboard.jsx
+++ b/frontend/src/components/Dashboard.jsx
@@ -1,0 +1,88 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+import MapView from './MapView';
+import ChartView from './ChartView';
+import { saveAs } from 'file-saver';
+import { jsPDF } from 'jspdf';
+
+// container for charts, map and filtering
+export default function Dashboard() {
+  const [records, setRecords] = useState([]);
+  const [start, setStart] = useState('');
+  const [end, setEnd] = useState('');
+  const [ship, setShip] = useState('');
+  const [status, setStatus] = useState('');
+
+  // load policy status data once
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await axios.get('/status');
+        setRecords(res.data);
+      } catch (err) {
+        console.error('Failed to fetch status', err);
+      }
+    }
+    load();
+  }, []);
+
+  // apply filters client-side
+  const filtered = records.filter((r) => {
+    if (ship && !r.ship_id.includes(ship)) return false;
+    if (status) {
+      if (status === 'active' && r.payout) return false;
+      if (status === 'payout' && !r.payout) return false;
+    }
+    if (start) {
+      const st = new Date(start);
+      const exp = new Date(r.policy.expected_eta);
+      if (exp < st) return false;
+    }
+    if (end) {
+      const ed = new Date(end);
+      const exp = new Date(r.policy.expected_eta);
+      if (exp > ed) return false;
+    }
+    return true;
+  });
+
+  // export filtered data as CSV file
+  function exportCSV() {
+    const rows = filtered.map((r) => `${r.ship_id},${r.policy.expected_eta},${r.payout}`);
+    const csv = ['ship_id,expected_eta,payout', ...rows].join('\n');
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    saveAs(blob, 'policies.csv');
+  }
+
+  // export simple PDF listing records
+  function exportPDF() {
+    const doc = new jsPDF();
+    doc.text('Policies', 10, 10);
+    filtered.forEach((r, i) => {
+      doc.text(`${r.ship_id} ${r.policy.expected_eta} ${r.payout ? 'PAYOUT' : 'ACTIVE'}`, 10, 20 + i * 10);
+    });
+    doc.save('policies.pdf');
+  }
+
+  return (
+    <div className="dashboard">
+      <h2>Policy Overview</h2>
+      {/* filtering controls */}
+      <div className="filters">
+        <input type="text" placeholder="Ship ID" value={ship} onChange={(e) => setShip(e.target.value)} />
+        <input type="datetime-local" value={start} onChange={(e) => setStart(e.target.value)} />
+        <input type="datetime-local" value={end} onChange={(e) => setEnd(e.target.value)} />
+        <select value={status} onChange={(e) => setStatus(e.target.value)}>
+          <option value="">All</option>
+          <option value="active">Active</option>
+          <option value="payout">Payout</option>
+        </select>
+        <button onClick={exportCSV}>Export CSV</button>
+        <button onClick={exportPDF}>Export PDF</button>
+      </div>
+      {/* pass filtered data to charts and map */}
+      <ChartView data={filtered} />
+      <MapView data={filtered} />
+    </div>
+  );
+}

--- a/frontend/src/components/MapView.jsx
+++ b/frontend/src/components/MapView.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { MapContainer, TileLayer, Marker, Polyline, Popup } from 'react-leaflet';
+import 'leaflet/dist/leaflet.css';
+
+// rough coordinates for the demo ports
+const PORT_COORDS = {
+  Dublin: [53.3498, -6.2603],
+  Hamburg: [53.5511, 9.9937],
+  Liverpool: [53.4084, -2.9916],
+  Rotterdam: [51.9244, 4.4777],
+  Cork: [51.8985, -8.4756],
+  Oslo: [59.9139, 10.7522],
+  Brest: [48.3904, -4.4861],
+  Gothenburg: [57.7089, 11.9746],
+  'Le Havre': [49.4944, 0.1079],
+  Stockholm: [59.3293, 18.0686],
+  Bilbao: [43.263, -2.935],
+  Tallinn: [59.437, 24.7535],
+  Amsterdam: [52.3676, 4.9041],
+  Copenhagen: [55.6761, 12.5683],
+  Antwerp: [51.2194, 4.4025],
+  Riga: [56.9496, 24.1052],
+  London: [51.5074, -0.1278],
+  'St Petersburg': [59.9311, 30.3609],
+  Lisbon: [38.7223, -9.1393],
+  Gdansk: [54.352, 18.6466],
+};
+
+// display shipment routes with simple weather popups
+export default function MapView({ data }) {
+  return (
+    <MapContainer center={[52, 5]} zoom={4} style={{ height: '400px', width: '100%' }}>
+      <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
+      {data.map((item) => {
+        const origin = PORT_COORDS[item.policy.origin] || [0, 0];
+        const dest = PORT_COORDS[item.policy.destination] || [0, 0];
+        return (
+          <React.Fragment key={item.ship_id}>
+            {/* route polyline colored by payout status */}
+            <Polyline positions={[origin, dest]} color={item.payout ? 'red' : 'green'} />
+            <Marker position={origin}>
+              <Popup>
+                {item.ship_id} - {item.policy.origin} ({item.policy.weather.conditions})
+              </Popup>
+            </Marker>
+            <Marker position={dest}>
+              <Popup>{item.policy.destination}</Popup>
+            </Marker>
+          </React.Fragment>
+        );
+      })}
+    </MapContainer>
+  );
+}


### PR DESCRIPTION
## Summary
- install chart & mapping libraries
- create `ChartView`, `MapView`, and `Dashboard` components
- export PDF/CSV from dashboard filters
- display charts and map in `App.jsx`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687818754d8c8329b91a41612a61df96