### PR TITLE
Add tx history and batch payout

### DIFF
--- a/agentic/agents/trigger_agent.py
+++ b/agentic/agents/trigger_agent.py
@@ -15,9 +15,14 @@ class TriggerAgent:
         self.contract_id = contract_id or os.getenv("CONTRACT_ID", "")
         # Keep track of successful payouts to avoid double calls
         self.payout_log: list[str] = []
+        # Log individual transactions with status and hash
+        self.tx_log: list[dict] = []
 
-    def _call_contract(self, ship_id: str) -> bool:
-        """Thin JSON-RPC wrapper around the check_and_payout call."""
+    def _call_contract(self, ship_id: str) -> str:
+        """Thin JSON-RPC wrapper around the check_and_payout call.
+
+        Returns a fake transaction hash for demo purposes.
+        """
         payload = {
             "jsonrpc": "2.0",
             "id": 1,
@@ -27,7 +32,10 @@ class TriggerAgent:
         resp = requests.post(self.rpc_url, json=payload, timeout=10)
         resp.raise_for_status()
         data = resp.json()
-        return data.get("result") == "success"
+        if data.get("result") == "success":
+            # Simulate the hash returned by a real blockchain
+            return f"0x{ship_id}abc"
+        return ""
 
     def register_actual_arrival(self, record: Dict) -> None:
         """Simulate calling the `register_actual_arrival` contract method."""
@@ -37,13 +45,34 @@ class TriggerAgent:
         print(f"Recorded arrival for {ship_id} at {actual}")
 
     def trigger_payout(self, record: Dict) -> bool:
-        """Send the transaction and return True if it succeeded."""
+        """Send the transaction and store status information."""
         ship_id = record["ship_id"]
+        # create initial pending entry
+        log_entry = {"ship_id": ship_id, "hash": "", "status": "pending"}
+        self.tx_log.append(log_entry)
         try:
-            if self._call_contract(ship_id):
+            tx_hash = self._call_contract(ship_id)
+            if tx_hash:
+                # mark transaction as confirmed and keep hash
+                log_entry["hash"] = tx_hash
+                log_entry["status"] = "confirmed"
                 self.payout_log.append(ship_id)
                 return True
+            # mark failure if no hash returned
+            log_entry["status"] = "failed"
             print(f"check_and_payout failed for {ship_id}")
         except Exception as exc:  # pragma: no cover - network failures
+            log_entry["status"] = "failed"
             print(f"RPC error for {ship_id}: {exc}")
         return False
+
+    def trigger_batch_payout(self, records: list[Dict]) -> list[str]:
+        """Process multiple payouts in sequence."""
+        processed: list[str] = []
+        for rec in records:
+            sid = rec["ship_id"]
+            if sid in self.payout_log:
+                continue
+            if self.trigger_payout(rec):
+                processed.append(sid)
+        return processed

--- a/agentic/main.py
+++ b/agentic/main.py
@@ -84,3 +84,17 @@ async def manual_check() -> Dict:
     # monitor() performs I/O and CPU work; offload to a thread to keep FastAPI async
     await asyncio.to_thread(monitor)
     return {"checked": True}
+
+
+@app.get("/txlog")
+async def tx_log() -> List[Dict]:
+    """Expose transaction history."""
+    return _trigger.tx_log
+
+
+@app.post("/batch-payout")
+async def batch_payout() -> Dict:
+    """Run payout for all eligible policies."""
+    records = _data_agent.fetch_latest()
+    processed = _trigger.trigger_batch_payout(records)
+    return {"processed": processed}

--- a/frontend/src/components/PolicyStatus.jsx
+++ b/frontend/src/components/PolicyStatus.jsx
@@ -6,6 +6,8 @@ export default function PolicyStatus() {
   // hold list of policy statuses returned from the backend
   const [statuses, setStatuses] = useState([]);
   const [loading, setLoading] = useState(true);
+  // message shown after batch payout completes
+  const [batchMsg, setBatchMsg] = useState('');
 
   // fetch status information when component mounts
   useEffect(() => {
@@ -24,16 +26,33 @@ export default function PolicyStatus() {
     fetchStatus();
   }, []);
 
+  // call backend to batch process payouts
+  const handleBatch = async () => {
+    try {
+      const res = await axios.post('/batch-payout');
+      setBatchMsg(`Processed: ${res.data.processed.join(', ')}`);
+    } catch (err) {
+      setBatchMsg('Batch payout failed');
+    }
+  };
+
   return (
     <div className="policy-status">
       <h2>Current Policies</h2>
+      <button onClick={handleBatch}>Run Batch Payout</button>
+      {batchMsg && <p>{batchMsg}</p>}
       {loading ? (
         <p>Loading...</p>
       ) : (
         <ul>
           {statuses.map((s) => (
             <li key={s.ship_id}>
-              {s.ship_id}: {s.payout ? 'Payout Triggered' : 'Active'}
+              {/* Show policy label */}
+              Policy #{s.ship_id}:{' '}
+              {/* Status badge with style */}
+              <span className={`status ${s.payout ? 'triggered' : 'active'}`}>
+                {s.payout ? 'Triggered' : 'Active'}
+              </span>
             </li>
           ))}
         </ul>

--- a/frontend/src/components/TxLog.jsx
+++ b/frontend/src/components/TxLog.jsx
@@ -3,17 +3,16 @@ import axios from 'axios';
 
 // Shows transaction history from the smart contract
 export default function TxLog() {
-  // log of transactions derived from payout status
+  // full transaction list from backend
   const [logs, setLogs] = useState([]);
+  // toggle to optionally show explorer links
+  const [showLinks, setShowLinks] = useState(false);
 
   useEffect(() => {
     async function fetchLogs() {
       try {
-        const res = await axios.get('/status');
-        const entries = res.data
-          .filter((p) => p.payout)
-          .map((p) => `Payout sent for ${p.ship_id}`);
-        setLogs(entries);
+        const res = await axios.get('/txlog');
+        setLogs(res.data);
       } catch (err) {
         console.error('Log fetch failed', err);
       }
@@ -24,9 +23,32 @@ export default function TxLog() {
   return (
     <div className="tx-log">
       <h2>Transaction Log</h2>
+      <label>
+        <input
+          type="checkbox"
+          checked={showLinks}
+          onChange={() => setShowLinks(!showLinks)}
+        />
+        Show explorer links
+      </label>
       <ul>
         {logs.map((l, i) => (
-          <li key={i}>{l}</li>
+          <li key={i}>
+            {/* Friendly policy label */}
+            Policy #{l.ship_id}{' '}
+            {/* Status badge */}
+            <span className={`status ${l.status}`}>{l.status}</span>{' '}
+            {/* Optional explorer link */}
+            {showLinks && l.hash && (
+              <a
+                href={`https://blockexplorer.com/tx/${l.hash}`}
+                target="_blank"
+                rel="noreferrer"
+              >
+                View
+              </a>
+            )}
+          </li>
         ))}
       </ul>
     </div>


### PR DESCRIPTION
## Summary
- log transaction status and hash in TriggerAgent
- expose `/txlog` and `/batch-payout` endpoints
- show policy status with badges and batch payout button
- improve TxLog with policy labels and optional explorer links

## Testing
- `pytest -q`
- `npm run build --silent` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687818789fd08329a90eb35229daaf81