### PR TITLE
Add tooltip, toast and inline validation

### DIFF
--- a/frontend/src/components/PolicyForm.jsx
+++ b/frontend/src/components/PolicyForm.jsx
@@ -1,5 +1,7 @@
 import React, { useState } from 'react';
 import axios from 'axios';
+import Tooltip from './Tooltip'; // explanatory tooltips
+import Toast from './Toast'; // toast notifications
 
 // Form for creating new insurance policies
 export default function PolicyForm() {
@@ -7,21 +9,55 @@ export default function PolicyForm() {
   const [shipId, setShipId] = useState('');
   const [expectedEta, setExpectedEta] = useState('');
   const [message, setMessage] = useState('');
+  const [errors, setErrors] = useState({ shipId: '', eta: '' });
+  const [toast, setToast] = useState('');
+  const [undoData, setUndoData] = useState(null); // store cleared data for undo
+
+  // simple validation helpers
+  const validateShipId = (val) => (!val ? 'Ship ID required' : '');
+  const validateEta = (val) => {
+    if (!val) return 'ETA required';
+    return new Date(val) <= new Date() ? 'ETA must be future' : '';
+  };
 
   // send data to backend when form is submitted
   const handleSubmit = async (e) => {
     e.preventDefault();
+    const shipError = validateShipId(shipId);
+    const etaError = validateEta(expectedEta);
+    setErrors({ shipId: shipError, eta: etaError });
+    if (shipError || etaError) return; // abort if validation fails
+
     try {
       const res = await axios.post('/policy', {
         ship_id: shipId,
         expected_eta: expectedEta,
       });
-      // show success message from API response
-      setMessage(`Created policy for ${res.data.ship_id}`);
+      // show toast message on success
+      setToast(`Created policy for ${res.data.ship_id}`);
+      setShipId('');
+      setExpectedEta('');
     } catch (err) {
       // display simple error message on failure
       setMessage('Failed to create policy');
     }
+  };
+
+  // clear form with undo option
+  const handleClear = () => {
+    setUndoData({ shipId, expectedEta });
+    setShipId('');
+    setExpectedEta('');
+    setToast('Form cleared');
+  };
+
+  const handleUndo = () => {
+    if (undoData) {
+      setShipId(undoData.shipId);
+      setExpectedEta(undoData.expectedEta);
+      setUndoData(null);
+    }
+    setToast('');
   };
 
   return (
@@ -31,19 +67,34 @@ export default function PolicyForm() {
         <label>Ship ID:</label>
         <input
           value={shipId}
-          onChange={(e) => setShipId(e.target.value)}
+          onChange={(e) => {
+            const val = e.target.value;
+            setShipId(val);
+            setErrors((err) => ({ ...err, shipId: validateShipId(val) }));
+          }}
         />
+        {errors.shipId && <span className="error">{errors.shipId}</span>}
       </div>
       <div>
-        <label>Expected ETA:</label>
+        <label>
+          Expected ETA
+          <Tooltip text="Estimated time of arrival" />
+        </label>
         <input
           type="datetime-local"
           value={expectedEta}
-          onChange={(e) => setExpectedEta(e.target.value)}
+          onChange={(e) => {
+            const val = e.target.value;
+            setExpectedEta(val);
+            setErrors((err) => ({ ...err, eta: validateEta(val) }));
+          }}
         />
+        {errors.eta && <span className="error">{errors.eta}</span>}
       </div>
       <button type="submit">Submit</button>
+      <button type="button" onClick={handleClear}>Clear</button>
       {message && <p>{message}</p>}
+      <Toast message={toast} onClose={() => setToast('')} onUndo={undoData && handleUndo} />
     </form>
   );
 }

--- a/frontend/src/components/Toast.jsx
+++ b/frontend/src/components/Toast.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+// Toast notification with optional undo action
+export default function Toast({ message, onClose, onUndo }) {
+  if (!message) return null;
+  return (
+    <div className="toast">
+      <span>{message}</span>
+      {onUndo && (
+        <button onClick={onUndo} className="toast-undo">Undo</button>
+      )}
+      <button onClick={onClose} className="toast-close">X</button>
+    </div>
+  );
+}

--- a/frontend/src/components/Tooltip.jsx
+++ b/frontend/src/components/Tooltip.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+// Simple tooltip to show explanatory text on hover
+export default function Tooltip({ text }) {
+  return (
+    <span className="tooltip">
+      ?
+      <span className="tooltip-text">{text}</span>
+    </span>
+  );
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import './styles.css'; // basic styles for tooltips and toasts
 
 // Mount the root React component
 ReactDOM.createRoot(document.getElementById('root')).render(

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,0 +1,40 @@
+.toast {
+  position: fixed;
+  bottom: 1rem;
+  right: 1rem;
+  background: #333;
+  color: #fff;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+}
+.toast button {
+  margin-left: 0.5rem;
+}
+.tooltip {
+  position: relative;
+  display: inline-block;
+  cursor: help;
+  margin-left: 4px;
+  color: #555;
+}
+.tooltip-text {
+  visibility: hidden;
+  background-color: #333;
+  color: #fff;
+  text-align: center;
+  padding: 2px 6px;
+  border-radius: 4px;
+  position: absolute;
+  z-index: 1;
+  bottom: 125%;
+  left: 50%;
+  transform: translateX(-50%);
+  white-space: nowrap;
+}
+.tooltip:hover .tooltip-text {
+  visibility: visible;
+}
+.error {
+  color: red;
+  font-size: 0.9rem;
+}


### PR DESCRIPTION
## Summary
- add `Tooltip` and `Toast` components
- apply tooltip, toast and inline validation in `PolicyForm`
- include basic CSS styles for toast and tooltip
- load styles globally

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687818825bf08329ba657d94f1039a83