### PR TITLE
Add polling for policy status and alerts

### DIFF
--- a/frontend/src/components/AlertBanner.jsx
+++ b/frontend/src/components/AlertBanner.jsx
@@ -6,7 +6,7 @@ export default function AlertBanner() {
   // message displayed when a payout has occurred
   const [alert, setAlert] = useState('');
 
-  // check backend for any triggered payouts
+  // check backend for any triggered payouts on a regular interval
   useEffect(() => {
     async function checkPayouts() {
       try {
@@ -19,7 +19,11 @@ export default function AlertBanner() {
         console.error('Alert fetch failed', err);
       }
     }
+
+    // run once immediately then every 5 seconds; consider WebSocket push later
     checkPayouts();
+    const id = setInterval(checkPayouts, 5000);
+    return () => clearInterval(id); // cleanup on unmount
   }, []);
 
   return (

--- a/frontend/src/components/PolicyStatus.jsx
+++ b/frontend/src/components/PolicyStatus.jsx
@@ -7,7 +7,7 @@ export default function PolicyStatus() {
   const [statuses, setStatuses] = useState([]);
   const [loading, setLoading] = useState(true);
 
-  // fetch status information when component mounts
+  // fetch status information when component mounts and poll regularly
   useEffect(() => {
     async function fetchStatus() {
       try {
@@ -21,7 +21,12 @@ export default function PolicyStatus() {
         setLoading(false);
       }
     }
+
+    // initial fetch
     fetchStatus();
+    // poll every 5 seconds; replace with WebSocket if backend supports it
+    const id = setInterval(fetchStatus, 5000);
+    return () => clearInterval(id); // cleanup when component unmounts
   }, []);
 
   return (


### PR DESCRIPTION
## Summary
- periodically fetch `/status` data in PolicyStatus and AlertBanner
- clear timers when components unmount
- comment about switching to WebSocket when backend allows