### PR TITLE
Add policy details fields with validation

### DIFF
--- a/agentic/main.py
+++ b/agentic/main.py
@@ -60,11 +60,29 @@ def shutdown_scheduler() -> None:
 
 @app.post("/policy")
 async def create_policy(policy: Dict) -> Dict:
-    """Store a new policy; expects at least a `ship_id` field."""
+    """Store a new policy; requires delay threshold, owner and payout."""
     ship_id = policy.get("ship_id")
+    delay = policy.get("delay_threshold")
+    owner = policy.get("owner")
+    payout = policy.get("payout_amount")
     if not ship_id:
         return {"error": "ship_id required"}
-    policies[ship_id] = policy
+    if delay is None or owner is None or payout is None:
+        return {"error": "missing fields"}
+    # numeric validation
+    try:
+        delay = int(delay)
+        payout = float(payout)
+    except ValueError:
+        return {"error": "invalid numeric values"}
+
+    policies[ship_id] = {
+        "ship_id": ship_id,
+        "expected_eta": policy.get("expected_eta"),
+        "delay_threshold": delay,
+        "owner": owner,
+        "payout_amount": payout,
+    }
     return {"status": "created", "ship_id": ship_id}
 
 

--- a/frontend/src/components/PolicyForm.jsx
+++ b/frontend/src/components/PolicyForm.jsx
@@ -6,21 +6,45 @@ export default function PolicyForm() {
   // keep local form state for ship ID and expected ETA
   const [shipId, setShipId] = useState('');
   const [expectedEta, setExpectedEta] = useState('');
+  const [delayThreshold, setDelayThreshold] = useState('');
+  const [owner, setOwner] = useState('');
+  const [payoutAmount, setPayoutAmount] = useState('');
   const [message, setMessage] = useState('');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
 
   // send data to backend when form is submitted
   const handleSubmit = async (e) => {
     e.preventDefault();
+    setError('');
+    setMessage('');
+
+    // basic validation for required and numeric fields
+    if (!shipId || !expectedEta || !delayThreshold || !owner || !payoutAmount) {
+      setError('All fields are required');
+      return;
+    }
+    if (isNaN(delayThreshold) || isNaN(payoutAmount)) {
+      setError('Threshold and payout must be numeric');
+      return;
+    }
+
+    setLoading(true);
     try {
       const res = await axios.post('/policy', {
         ship_id: shipId,
         expected_eta: expectedEta,
+        delay_threshold: Number(delayThreshold),
+        owner,
+        payout_amount: Number(payoutAmount),
       });
       // show success message from API response
       setMessage(`Created policy for ${res.data.ship_id}`);
     } catch (err) {
       // display simple error message on failure
-      setMessage('Failed to create policy');
+      setError('Failed to create policy');
+    } finally {
+      setLoading(false);
     }
   };
 
@@ -44,7 +68,38 @@ export default function PolicyForm() {
           onChange={(e) => setExpectedEta(e.target.value)}
         />
       </div>
-      <button className="bg-primary text-white px-2 py-1" type="submit">Submit</button>
+      <div className="flex flex-col">
+        <label className="caption">Delay Threshold (hrs):</label>
+        <input
+          className="border p-1"
+          value={delayThreshold}
+          onChange={(e) => setDelayThreshold(e.target.value)}
+        />
+      </div>
+      <div className="flex flex-col">
+        <label className="caption">Owner Address:</label>
+        <input
+          className="border p-1"
+          value={owner}
+          onChange={(e) => setOwner(e.target.value)}
+        />
+      </div>
+      <div className="flex flex-col">
+        <label className="caption">Payout Amount:</label>
+        <input
+          className="border p-1"
+          value={payoutAmount}
+          onChange={(e) => setPayoutAmount(e.target.value)}
+        />
+      </div>
+      <button
+        className="bg-primary text-white px-2 py-1"
+        disabled={loading}
+        type="submit"
+      >
+        {loading ? 'Submitting...' : 'Submit'}
+      </button>
+      {error && <p className="caption text-red-600">{error}</p>}
       {message && <p className="caption">{message}</p>}
     </form>
   );


### PR DESCRIPTION
## Summary
- expand policy form to collect delay threshold, owner and payout
- send these new fields in the POST request
- validate form input on the frontend with loading/error states
- enforce required fields and numeric checks on backend