### PR TITLE
Add explorer links to tx log

### DIFF
--- a/agentic/main.py
+++ b/agentic/main.py
@@ -100,9 +100,11 @@ async def tx_log() -> List[Dict]:
     """Expose transaction history with friendly labels."""
     return [
         {
-            "label": f"Policy #{tx['ship_id']}",
+            "policy_id": tx.get("policy_id", tx.get("ship_id")),
+            "label": f"Policy #{tx.get('policy_id', tx.get('ship_id'))}",
             "status": tx["status"],
-            "explorer": f"{_trigger.explorer_url}/{tx['tx_id']}" if _trigger.explorer_url else None,
+            # explorer link already stored in the transaction entry
+            "explorer": tx.get("explorer"),
         }
         for tx in _trigger.transactions
     ]

--- a/frontend/src/components/TxLog.jsx
+++ b/frontend/src/components/TxLog.jsx
@@ -34,7 +34,7 @@ export default function TxLog() {
                   : 'bg-red-200'
               }`}
             >
-              {l.status}
+              {l.status === 'confirmed' ? 'Payout Confirmed' : l.status}
             </span>
             {l.explorer && (
               <a
@@ -43,7 +43,7 @@ export default function TxLog() {
                 rel="noopener noreferrer"
                 className="underline text-xs"
               >
-                View
+                View on Explorer
               </a>
             )}
           </li>


### PR DESCRIPTION
## Summary
- support optional EXPLORER_URL configuration when instantiating `TriggerAgent`
- store `policy_id` and explorer link with each transaction record
- expose those fields in `/txlog` API
- update `TxLog.jsx` UI wording and explorer link text